### PR TITLE
CircleCI configurations support: nodejs version 8 and 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,7 @@ version: 2
 commands:
   test-nodejs:
     steps:
-      - run:
-          name: Versions
-          command: npm version
-      - checkout:
+      - checkout
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -53,6 +50,7 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
+      - node-v4
       - node-v6
       - node-v8
       - node-v10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,6 @@ commands:
           command: npm test
 
 jobs:
-  node-v6:
-    docker:
-      - image: node:6
-    steps:
-      - test-nodejs
   node-v8:
     docker:
       - image: node:8
@@ -43,6 +38,5 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
-      - node-v6
       - node-v8
       - node-v10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,14 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
-jobs:
-  build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:8.10
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    # working_directory: ~/repo
-
+commands:
+  test-nodejs:
     steps:
-      - checkout
-
+      - run:
+          name: Versions
+          command: npm version
+      - checkout:
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -35,5 +27,34 @@ jobs:
 
       # run tests!
       - run: npm run test
+
+jobs:
+  node-v4:
+    docker:
+      - image: node:4
+    steps:
+      - test-nodejs
+  node-v6:
+    docker:
+      - image: node:6
+    steps:
+      - test-nodejs
+  node-v8:
+    docker:
+      - image: node:8
+    steps:
+      - test-nodejs
+  node-v10:
+    docker:
+      - image: node:10
+    steps:
+      - test-nodejs
+
+workflows:
+  node-multi-build:
+    jobs:
+      - node-v6
+      - node-v8
+      - node-v10
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,39 @@
 # Javascript Node CircleCI 2.0 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
-version: 2
+# Template: https://github.com/teppeis-sandbox/circleci2-multiple-node-versions/blob/npm/.circleci/config.yml
+
+version: 2.1
 
 commands:
   test-nodejs:
     steps:
+      - run:
+          name: Versions
+          command: npm version
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
-      - run: npm install
-
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}
+      - run:
+          name: Install dependencies
+          command: npm run test
+      - run:
+          name: Test
+          command: npm test
+      - save-npm-cache
+  save-npm-lock:
+    steps:
       - save_cache:
+          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-lock-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-
-      # run tests!
-      - run: npm run test
+  save-npm-cache:
+    steps:
+      - save_cache:
+          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.npm/_cacache
 
 jobs:
   node-v4:
@@ -50,9 +60,7 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
-      - node-v4
+      - node-v6
       - node-v6
       - node-v8
       - node-v10
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,37 +5,25 @@ version: 2.1
 commands:
   test-nodejs:
     steps:
-      - run:
-          name: Versions
-          command: npm version
       - checkout
       - restore_cache:
           keys:
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: Install dependencies
-          command: npm install
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
       - run:
           name: Test
           command: npm test
-      - save-npm-cache
-  save-npm-lock:
-    steps:
-      - save_cache:
-          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-lock-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
-  save-npm-cache:
-    steps:
-      - save_cache:
-          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-          paths:
-            - ~/.npm/_cacache
 
 jobs:
-    steps:
-      - test-nodejs
   node-v6:
     docker:
       - image: node:6
@@ -55,7 +43,6 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
-      - node-v6
       - node-v6
       - node-v8
       - node-v10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,3 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
 # Template: https://github.com/teppeis-sandbox/circleci2-multiple-node-versions/blob/npm/.circleci/config.yml
 
 version: 2.1
@@ -17,7 +15,7 @@ commands:
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Install dependencies
-          command: npm run test
+          command: npm install
       - run:
           name: Test
           command: npm test
@@ -36,9 +34,6 @@ commands:
             - ~/.npm/_cacache
 
 jobs:
-  node-v4:
-    docker:
-      - image: node:4
     steps:
       - test-nodejs
   node-v6:


### PR DESCRIPTION
PR brings two build process: 
- nodejs version 8 
- nodejs version 10

Example: https://circleci.com/gh/dimitardanailov/organic-watch-json-dir/tree/master
Build numbers are `11` and `12`

Nodejs version 6 is not supported: https://circleci.com/gh/dimitardanailov/organic-watch-json-dir/9
Reason: Arrow functions are not supported :(